### PR TITLE
Rails 6 Unable To Convert Unpermitted Parameters To Hash Fix

### DIFF
--- a/lib/rubycas-client-rails.rb
+++ b/lib/rubycas-client-rails.rb
@@ -377,7 +377,7 @@ module RubyCAS
         
         params = controller.params.dup
         params.delete(:ticket)
-        service_url = controller.url_for(params)
+        service_url = controller.url_for(params.to_enum.to_h)
         log.debug("Guessed service url: #{service_url.inspect}")
         return service_url
       end

--- a/rubycas-client-rails.gemspec
+++ b/rubycas-client-rails.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = %q{rubycas-client-rails}
-  s.version = "0.1.1"
+  s.version = "0.1.2"
 
   s.authors = ["Matt Zukowski"]
   s.date = %q{2011-08-13}


### PR DESCRIPTION
Since Rails 5, ActionController::Parameters no longer inherits from Hash, in an attempt to discourage people from using Hash-related methods on the request parameters without explicitly filtering them.

It would produce this error: `unable to convert unpermitted parameters to hash`

This change fixes the breakage of this lib in Rails 6 applications. From my testing, it's backwards compatible with Rails 4.

If there is a preferred way you'd like this to be fixed let me know and I'll be happy to oblige 👍 