### PR TITLE
Rails 7 Security CAS Fix for Nucleus

### DIFF
--- a/lib/rubycas-client-rails.rb
+++ b/lib/rubycas-client-rails.rb
@@ -275,7 +275,7 @@ module RubyCAS
         controller.session[:previous_redirect_to_cas] = Time.now
         
         log.debug("Redirecting to #{redirect_url.inspect}")
-        controller.send(:redirect_to, redirect_url)
+        controller.send(:redirect_to, redirect_url, allow_other_host: true)
       end
       
       private

--- a/rubycas-client-rails.gemspec
+++ b/rubycas-client-rails.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = %q{rubycas-client-rails}
-  s.version = "0.1.2"
+  s.version = "0.1.3"
 
   s.authors = ["Matt Zukowski"]
   s.date = %q{2011-08-13}


### PR DESCRIPTION
For Rails 7 we need to add allow_other_host: true to avoid Rails security measures throwing an error. This fixes that problem and is backwards compatible.